### PR TITLE
Create Network-Device-Cfg-Backup.py

### DIFF
--- a/Network-Device-Cfg-Backup.py
+++ b/Network-Device-Cfg-Backup.py
@@ -1,0 +1,29 @@
+from netmiko import ConnectHandler
+import getpass
+import os
+
+location = '/home/venkat/Documents/SDN_bckup_Cfg/'
+#host = input("Enter Hostname: ")
+username = input("Enter Username: ")
+password = getpass.getpass()
+user_cmd = input("Enter command: ")
+
+with open("Hosts.txt", 'r') as hostsfile:
+    for line in hostsfile:
+        hostline = line.strip()
+        cisco = {
+            'device_type': 'cisco_ios', 
+            'host': hostline,
+            'username': username, 
+            'password': password,
+            'secret': 'admin',
+        }
+        net_connect = ConnectHandler(**cisco)
+        net_connect.enable()
+        output = net_connect.send_command(user_cmd)
+        #print(output)
+
+        outputfile = os.path.join(location, hostline +".txt")
+        with open(outputfile, 'w') as result:
+            x = result.write(output)
+            print(x)


### PR DESCRIPTION
This will python script will backup configuration files into text files to a required directory using Netmiko library.
Note: only enter IP address of device in input text file one-by-one only.
Using "User_cmd:" which is a single command that user want's to use on device and get information from it. The Outputfile name format is "IP Address".txt which means each device configuration will be saved as a text file with its IP Address as file name individually. So, If there are list of 10 devices in input file then there would be 10 output files created with result.